### PR TITLE
Small fix to tests to prevent failure.

### DIFF
--- a/mockredis/tests/test_redis.py
+++ b/mockredis/tests/test_redis.py
@@ -8,7 +8,7 @@ class TestRedis(TestCase):
         self.redis.flushdb()
 
     def test_get(self):
-        self.assertEqual('', self.redis.get('key'))
+        self.assertEqual(None, self.redis.get('key'))
 
         self.redis.redis['key'] = 'value'
         self.assertEqual('value', self.redis.get('key'))


### PR DESCRIPTION
Without this, I get:

```
marc@hyperion:~/dev/git-repos/mockredis
09:22:09 $ python setup.py test
running test
running egg_info
writing mockredis.egg-info/PKG-INFO
writing namespace_packages to mockredis.egg-info/namespace_packages.txt
writing top-level names to mockredis.egg-info/top_level.txt
writing dependency_links to mockredis.egg-info/dependency_links.txt
reading manifest file 'mockredis.egg-info/SOURCES.txt'
writing manifest file 'mockredis.egg-info/SOURCES.txt'
running build_ext
test_get (mockredis.tests.test_redis.TestRedis) ... FAIL
test_set (mockredis.tests.test_redis.TestRedis) ... ok

======================================================================
FAIL: test_get (mockredis.tests.test_redis.TestRedis)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marc/dev/git-repos/mockredis/mockredis/tests/test_redis.py", line 11, in test_get
    self.assertEqual('', self.redis.get('key'))
AssertionError: '' != None

----------------------------------------------------------------------
Ran 2 tests in 0.001s

FAILED (failures=1)
```
