### PR TITLE
Attempt to fix problems with using mockredis from another project by removing namespace package stuff.

### DIFF
--- a/mockredis/__init__.py
+++ b/mockredis/__init__.py
@@ -1,6 +1,3 @@
-__import__('pkg_resources').declare_namespace(__name__)
-
-
 from mockredis.redis import MockRedis, mock_redis_client
 
 __all__ = ["MockRedis", "mock_redis_client"]

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,6 @@ setup(name='mockredis',
       url='http://www.github.com/locationlabs/mockredis',
       license='Apache2',
       packages=find_packages(exclude=['*.tests']),
-      namespace_packages=[
-          'mockredis'
-      ],
       setup_requires=[
           'nose>=1.0'
       ],


### PR DESCRIPTION
I had been trying to use mockredis by installing
`git+git://github.com/locationlabs/mockredis.git@f76bebfe369c84eb7894915dac77058e217d4f4b`
and it seems to not work right, because it gets installed without
`mockredis/__init__.py` -- see below:

```
marc@hyperion:~/dev/git-repos/mockredis
09:38:38 $ virtualenv --distribute --no-site-packages show-mockredis-packaging-bug.venv
New python executable in show-mockredis-packaging-bug.venv/bin/python
Installing distribute..........................................................................................................................................................................................................done.
Installing pip................done.

marc@hyperion:~/dev/git-repos/mockredis
09:38:48 $ source show-mockredis-packaging-bug.venv/bin/activate

(show-mockredis-packaging-bug.venv)
marc@hyperion:~/dev/git-repos/mockredis
09:40:01 $ pip install git+git://github.com/locationlabs/mockredis.git@f76bebfe369c84eb7894915dac77058e217d4f4b
Downloading/unpacking git+git://github.com/locationlabs/mockredis.git@f76bebfe369c84eb7894915dac77058e217d4f4b
  Cloning git://github.com/locationlabs/mockredis.git (to f76bebfe369c84eb7894915dac77058e217d4f4b) to /var/folders/EV/EVpZ2D-dFr0Q0VP8cVxFc++++TI/-Tmp-/pip-CyMBXo-build
  Could not find a tag or branch 'f76bebfe369c84eb7894915dac77058e217d4f4b', assuming commit.
  Running setup.py egg_info for package from git+git://github.com/locationlabs/mockredis.git@f76bebfe369c84eb7894915dac77058e217d4f4b
    no previously-included directories found matching 'doc/.build'

    Installed /private/var/folders/EV/EVpZ2D-dFr0Q0VP8cVxFc++++TI/-Tmp-/pip-CyMBXo-build/nose-1.2.1-py2.7.egg

Installing collected packages: mockredis
  Running setup.py install for mockredis
    Skipping installation of /Users/marc/dev/git-repos/mockredis/show-mockredis-packaging-bug.venv/lib/python2.7/site-packages/mockredis/__init__.py (namespace package)

    Installing /Users/marc/dev/git-repos/mockredis/show-mockredis-packaging-bug.venv/lib/python2.7/site-packages/mockredis-1.0-py2.7-nspkg.pth
Successfully installed mockredis
Cleaning up...

(show-mockredis-packaging-bug.venv)
marc@hyperion:~/dev/git-repos/mockredis
09:40:45 $ python
Python 2.7.3 (v2.7.3:70274d53c1dd, Apr  9 2012, 20:52:43) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import mockredis
>>> dir(mockredis)
['__doc__', '__name__', '__path__']
>>> ^D
(show-mockredis-packaging-bug.venv)
marc@hyperion:~/dev/git-repos/mockredis
09:40:57 $ ls -l show-mockredis-packaging-bug.venv/lib/python2.7/site-packages/mock
mockredis/                     mockredis-1.0-py2.7-nspkg.pth  mockredis-1.0-py2.7.egg-info/  
(show-mockredis-packaging-bug.venv)
marc@hyperion:~/dev/git-repos/mockredis
09:40:57 $ ls -l show-mockredis-packaging-bug.venv/lib/python2.7/site-packages/mockredis/
total 72
-rw-r--r--  1 marc  marc    613 Nov 12 09:40 lock.py
-rw-r--r--  1 marc  marc   1522 Nov 12 09:40 lock.pyc
-rw-r--r--  1 marc  marc    650 Nov 12 09:40 pipeline.py
-rw-r--r--  1 marc  marc   1825 Nov 12 09:40 pipeline.pyc
-rw-r--r--  1 marc  marc   7076 Nov 12 09:40 redis.py
-rw-r--r--  1 marc  marc  11876 Nov 12 09:40 redis.pyc
```

If I use my repo and branch (with the change in this PR applied -- `git+git://github.com/msabramo/mockredis.git@fix-packaging`), then it works properly:

```
(show-mockredis-packaging-bug.venv)
marc@hyperion:~/dev/git-repos/mockredis
10:12:40 $ deactivate 

marc@hyperion:~/dev/git-repos/mockredis
10:12:44 $ virtualenv --distribute --no-site-packages show-mockredis-packaging-bug-2.venv
New python executable in show-mockredis-packaging-bug-2.venv/bin/python
Installing distribute..........................................................................................................................................................................................................done.
Installing pip................done.

marc@hyperion:~/dev/git-repos/mockredis
10:13:36 $ source show-mockredis-packaging-bug-2.venv/bin/activate

(show-mockredis-packaging-bug-2.venv)
marc@hyperion:~/dev/git-repos/mockredis
10:14:00 $ pip install git+git://github.com/msabramo/mockredis.git@fix-packaging
Downloading/unpacking git+git://github.com/msabramo/mockredis.git@fix-packaging
  Cloning git://github.com/msabramo/mockredis.git (to fix-packaging) to /var/folders/EV/EVpZ2D-dFr0Q0VP8cVxFc++++TI/-Tmp-/pip-tp3HGK-build
  Running setup.py egg_info for package from git+git://github.com/msabramo/mockredis.git@fix-packaging
    no previously-included directories found matching 'doc/.build'

    Installed /private/var/folders/EV/EVpZ2D-dFr0Q0VP8cVxFc++++TI/-Tmp-/pip-tp3HGK-build/nose-1.2.1-py2.7.egg

Installing collected packages: mockredis
  Running setup.py install for mockredis

Successfully installed mockredis
Cleaning up...

(show-mockredis-packaging-bug-2.venv)
marc@hyperion:~/dev/git-repos/mockredis
10:15:48 $ python
Python 2.7.3 (v2.7.3:70274d53c1dd, Apr  9 2012, 20:52:43) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import mockredis
>>> dir(mockredis)
['MockRedis', '__all__', '__builtins__', '__doc__', '__file__', '__name__', '__package__', '__path__', 'lock', 'mock_redis_client', 'redis']
>>> ^D
(show-mockredis-packaging-bug-2.venv)
marc@hyperion:~/dev/git-repos/mockredis
10:15:58 $ ls -l show-mockredis-packaging-bug-2.venv/lib/python2.7/site-packages/mockredis/
total 88
-rw-r--r--  1 marc  marc    103 Nov 12 10:14 __init__.py
-rw-r--r--  1 marc  marc    342 Nov 12 10:14 __init__.pyc
-rw-r--r--  1 marc  marc    613 Nov 12 10:14 lock.py
-rw-r--r--  1 marc  marc   1532 Nov 12 10:14 lock.pyc
-rw-r--r--  1 marc  marc    650 Nov 12 10:14 pipeline.py
-rw-r--r--  1 marc  marc   1837 Nov 12 10:14 pipeline.pyc
-rw-r--r--  1 marc  marc   7076 Nov 12 10:14 redis.py
-rw-r--r--  1 marc  marc  11948 Nov 12 10:14 redis.pyc
```
