### PR TITLE
llen method + lrange fixes

### DIFF
--- a/mockredis/redis.py
+++ b/mockredis/redis.py
@@ -209,13 +209,11 @@ class MockRedis(object):
     def lrange(self, key, start, stop):
         """Emulate lrange."""
 
-        # Does the set at this key already exist?
-        if key in self.redis:
-            # Yes, add this to the list
-            return map(str, self.redis[key][start:stop + 1 if stop != -1 else None])
-        else:
-            # No, override the defaultdict's default and create the list
-            self.redis[key] = list([])
+        if key not in self.redis:
+            return []
+        # convert start and stop to positive indexes
+        start, stop = (len(self.redis[key])+s if s < 0 else s for s in [start, stop])
+        return map(str, self.redis[key][start:stop+1])
 
     def lindex(self, key, index):
         """Emulate lindex."""

--- a/mockredis/tests/test_redis.py
+++ b/mockredis/tests/test_redis.py
@@ -109,8 +109,21 @@ class TestRedis(TestCase):
                               str(v))
 
     def test_llen(self):
-        key = 'key'
-        self.assertEqual(self.redis.llen(key), 0)
-        self.assertFalse(self.redis.exists(key))
-        self.redis.rpush(key, 'value')
-        self.assertEqual(self.redis.llen(key), 1)
+        self.assertEqual(self.redis.llen('key'), 0)
+        self.assertFalse(self.redis.exists('key'))
+        self.redis.rpush('key', 'value')
+        self.assertEqual(self.redis.llen('key'), 1)
+
+    def test_lrange(self):
+        self.assertEqual(self.redis.lrange('key', 0, 100), [])
+        self.assertFalse(self.redis.exists('key'))
+        for i in range(3):
+            self.redis.rpush('key', i)
+        self.assertEqual(self.redis.lrange('key', 2, 0), [])
+        self.assertEqual(self.redis.lrange('key', 0, 100), ['0', '1', '2'])
+        self.assertEqual(self.redis.lrange('key', 0, 2), ['0', '1', '2'])
+        self.assertEqual(self.redis.lrange('key', 1, 1), ['1'])
+        self.assertEqual(self.redis.lrange('key', 1, -1), ['1', '2'])
+        self.assertEqual(self.redis.lrange('key', 1, -2), ['1'])
+        self.assertEqual(self.redis.lrange('key', -3, -2), ['0', '1'])
+        self.assertEqual(self.redis.lrange('key', -1, -1), ['2'])


### PR DESCRIPTION
I've added `llen` method and fixed `lrange` to behave like described in `LRANGE` documentation (I've tested it also against redis-py).
