### PR TITLE
Calling a script on a pipeline bug.

### DIFF
--- a/mockredis/pipeline.py
+++ b/mockredis/pipeline.py
@@ -24,8 +24,13 @@ class MockRedisPipeline(MockRedis):
         Emulate the execute method. All piped
         commands are executed immediately
         in this mock, so this is a no-op.
+
+        We're still interested in the results though.
+
         """
-        pass
+        results = self.results
+        self.results = []
+        return results
 
     def __exit__(self, *argv, **kwargs):
         pass

--- a/mockredis/redis.py
+++ b/mockredis/redis.py
@@ -262,7 +262,18 @@ class MockRedis(object):
         """Emulate hget."""
 
         redis_hash = self._get_hash(hashkey, 'HGET')
-        return redis_hash.get(str(attribute))
+        return self.result(redis_hash.get(str(attribute)))
+
+    def result(self, result):
+        from pipeline import MockRedisPipeline
+        if isinstance(self, MockRedisPipeline):
+            self.results.append(result)
+            print "pipeline results now: ", self.results
+            return result
+        if self.pipe:
+            print "pipeline results now: ", self.pipe.results
+            self.pipe.results.append(result)
+        return result
 
     def hgetall(self, hashkey):
         """Emulate hgetall."""
@@ -302,7 +313,7 @@ class MockRedis(object):
 
         redis_hash = self._get_hash(hashkey, 'HMGET')
         attributes = self._list_or_args(keys, args)
-        return [redis_hash.get(str(attribute)) for attribute in attributes]
+        return self.result([redis_hash.get(str(attribute)) for attribute in attributes])
 
     def hset(self, hashkey, attribute, value):
         """Emulate hset."""


### PR DESCRIPTION
I was getting attribute errors executing a script on a pipeline.

These changes seem to fix the problem.
