### PR TITLE
Allow lock to be used as context manager

### DIFF
--- a/mockredis/lock.py
+++ b/mockredis/lock.py
@@ -22,3 +22,9 @@ class MockRedisLock(object):
         """Emulate release."""
 
         return
+
+    def __enter__(self):
+        return self.acquire()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.release()


### PR DESCRIPTION
This is useful when the lock is used in this manner in actual code.
