### PR TITLE
raise ResponseError if an empty list is passed to SADD

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+ - SADD will raise an exception if an empty list is passed to it
+
 Version 2.9.0.8
 
  - Add inclusive syntax (parenthesis) support for zero sets ZRANGEBYSCORE, ZREVRANGEBYSCORE  & ZREMRANGEBYSCORE

--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -830,6 +830,8 @@ class MockRedis(object):
 
     def sadd(self, key, *values):
         """Emulate sadd."""
+        if len(values) == 0:
+            raise ResponseError("wrong number of arguments for 'sadd' command")
         redis_set = self._get_set(key, 'SADD', create=True)
         before_count = len(redis_set)
         redis_set.update(map(str, values))

--- a/mockredis/tests/test_set.py
+++ b/mockredis/tests/test_set.py
@@ -1,5 +1,6 @@
 from nose.tools import assert_raises, eq_, ok_
 
+from mockredis.exceptions import ResponseError
 from mockredis.tests.fixtures import setup
 
 
@@ -8,6 +9,12 @@ class TestRedisSet(object):
 
     def setup(self):
         setup(self)
+
+    def test_sadd_empty(self):
+        key = "set"
+        values = []
+        with assert_raises(ResponseError):
+            self.redis.sadd(key, *values)
 
     def test_sadd(self):
         key = "set"


### PR DESCRIPTION
Redis SADD will raise an error if an empty list is passed to it

![screenshot 2014-06-04 12 29 29](https://cloud.githubusercontent.com/assets/1268088/3171865/b691f808-ebcc-11e3-934a-e8b27b705e23.png)

(I really hope I got the flow this time. sorry for messing up in previous PRs)
