### PR TITLE
Fix the TTL -1/-2/None confusion - it varies by strictness.

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -174,21 +174,6 @@ class MockRedis(object):
             return True
         return False
 
-    def _time_to_live(self, key, output_ms):
-        """
-        Returns time to live in milliseconds if output_ms is True, else returns seconds.
-        """
-        if key not in self.redis:
-            # as of redis 2.8, -2 returned if key does not exist
-            return long(-2)
-        if key not in self.timeouts:
-            # redis-py returns None; command docs say -1
-            return None
-
-        get_result = get_total_milliseconds if output_ms else get_total_seconds
-        time_to_live = get_result(self.timeouts[key] - self.clock.now())
-        return long(max(-1, time_to_live))
-
     def ttl(self, key):
         """
         Emulate ttl
@@ -202,7 +187,10 @@ class MockRedis(object):
         :returns: the number of seconds till timeout, None if the key does not exist or if the
                   key has no timeout(as per the redis-py lib behavior).
         """
-        return self._time_to_live(key, output_ms=False)
+        value = self.pttl(key)
+        if value is None or value < 0:
+            return value
+        return value // 1000
 
     def pttl(self, key):
         """
@@ -212,7 +200,19 @@ class MockRedis(object):
         :returns: the number of milliseconds till timeout, None if the key does not exist or if the
                   key has no timeout(as per the redis-py lib behavior).
         """
-        return self._time_to_live(key, output_ms=True)
+        """
+        Returns time to live in milliseconds if output_ms is True, else returns seconds.
+        """
+        if key not in self.redis:
+            # as of redis 2.8, -2 is returned if the key does not exist
+            return long(-2) if self.strict else None
+        if key not in self.timeouts:
+            # as of redis 2.8, -1 is returned if the key is persistent
+            # redis-py returns None; command docs say -1
+            return long(-1) if self.strict else None
+
+        time_to_live = get_total_milliseconds(self.timeouts[key] - self.clock.now())
+        return long(max(-1, time_to_live))
 
     def do_expire(self):
         """
@@ -1381,13 +1381,6 @@ class MockRedis(object):
         if isinstance(score, basestring) and score[0] == '(':
             return False, float(score[1:])
         return True, float(score)
-
-
-def get_total_seconds(td):
-    """
-    For python 2.6 support
-    """
-    return int((td.microseconds + (td.seconds + td.days * 24 * 3600) * 1e6) // 1e6)
 
 
 def get_total_milliseconds(td):

--- a/mockredis/tests/test_redis.py
+++ b/mockredis/tests/test_redis.py
@@ -112,12 +112,15 @@ class TestRedis(object):
         """
         Test absent ttl handling.
         """
-        # redis >= 2.8.0 return -2 if key does exist
-        eq_(self.redis.ttl("invalid_key"), -2)
-
-        # redis-py return None if there is no pttl
+        eq_(self.redis.ttl("invalid_key"), None)
         self.redis.set("key", "value")
         eq_(self.redis.ttl("key"), None)
+
+        # redis >= 2.8.0 returns -2 if the key does exist
+        eq_(self.redis_strict.ttl("invalid_key"), -2)
+        # redis >= 2.8.0 returns -1 if there is no ttl
+        self.redis_strict.set("key", "value")
+        eq_(self.redis_strict.ttl("key"), -1)
 
     def test_ttl_no_timeout(self):
         """
@@ -140,12 +143,15 @@ class TestRedis(object):
         """
         Test absent pttl handling.
         """
-        # redis >= 2.8.0 return -2 if key does exist
-        eq_(self.redis.pttl("invalid_key"), -2)
+        # redis >= 2.8.0 returns -2 if the key does exist
+        eq_(self.redis.pttl("invalid_key"), None)
+        eq_(self.redis_strict.pttl("invalid_key"), -2)
 
-        # redis-py return None if there is no pttl
+        # redis >= 2.8.0 returns -1 if there is no ttl
         self.redis.set("key", "value")
         eq_(self.redis.pttl("key"), None)
+        self.redis_strict.set("key", "value")
+        eq_(self.redis_strict.pttl("key"), -1)
 
     def test_pttl_no_timeout(self):
         """

--- a/mockredis/tests/test_string.py
+++ b/mockredis/tests/test_string.py
@@ -61,12 +61,7 @@ class TestRedisString(object):
 
         # check that the value wasn't updated
         ok_(value != self.redis.get(key), msg)
-        if self.redis.exists(key):
-            # check that the expiration was not set
-            eq_(self.redis.ttl(key), None)
-        else:
-            # check that the expiration was not set
-            eq_(self.redis.ttl(key), -2)
+        eq_(self.redis.ttl(key), None)
 
     def _assert_was_set(self, key, value, config, msg, delta=1):
         """Assert that the key was set along with timeout if applicable"""
@@ -266,7 +261,7 @@ class TestRedisString(object):
         # verify if the keys that were to be deleted, were deleted along with the timeouts.
         for key in set(to_create) & set(to_delete):
             ok_(key not in self.redis)
-            eq_(self.redis.ttl(key), -2)
+            eq_(self.redis.ttl(key), None)
 
         # verify if the keys not to be deleted, were not deleted and their timeouts not removed.
         for key in set(to_create) - (set(to_create) & set(to_delete)):


### PR DESCRIPTION
-1/-2 are returned by StrictRedis; None is returned when using non-strict.
