### PR TITLE
Prefer using redis-py's exception classes over our own.

### DIFF
--- a/mockredis/exceptions.py
+++ b/mockredis/exceptions.py
@@ -1,15 +1,20 @@
 """
-Emulates exceptions raised by the Redis client.
+Emulates exceptions raised by the Redis client, if necessary.
 """
 
+try:
+    # Prefer actual exceptions to defining our own, so code that swaps
+    # in implementations does not have to swap in different exception
+    # classes.
+    from redis.exceptions import RedisError, ResponseError, WatchError
+except ImportError:
+    class RedisError(Exception):
+        pass
 
-class RedisError(Exception):
-    pass
+
+    class ResponseError(RedisError):
+        pass
 
 
-class ResponseError(Exception):
-    pass
-
-
-class WatchError(Exception):
-    pass
+    class WatchError(RedisError):
+        pass


### PR DESCRIPTION
Our own tests run into this issue - when using --use-redis we expected a mockredis exception, but got a redis-py exception.
