### PR TITLE
hset and hmset proper return values

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -454,6 +454,7 @@ class MockRedis(object):
         for key, value in value.items():
             attribute = str(key)
             redis_hash[attribute] = str(value)
+        return True
 
     def hmget(self, hashkey, keys, *args):
         """Emulate hmget."""
@@ -467,7 +468,11 @@ class MockRedis(object):
 
         redis_hash = self._get_hash(hashkey, 'HSET', create=True)
         attribute = str(attribute)
-        redis_hash[attribute] = str(value)
+        if attribute in redis_hash and redis_hash[attribute] == value:
+            return long(0)
+        else:
+            redis_hash[attribute] = str(value)
+            return long(1)
 
     def hsetnx(self, hashkey, attribute, value):
         """Emulate hsetnx."""
@@ -475,10 +480,10 @@ class MockRedis(object):
         redis_hash = self._get_hash(hashkey, 'HSETNX', create=True)
         attribute = str(attribute)
         if attribute in redis_hash:
-            return 0
+            return long(0)
         else:
             redis_hash[attribute] = str(value)
-            return 1
+            return long(1)
 
     def hincrby(self, hashkey, attribute, increment=1):
         """Emulate hincrby."""

--- a/mockredis/tests/test_hash.py
+++ b/mockredis/tests/test_hash.py
@@ -42,7 +42,8 @@ class TestRedisHash(object):
 
     def test_hset(self):
         hashkey = "hash"
-        self.redis.hset(hashkey, "key", "value")
+        eq_(1, self.redis.hset(hashkey, "key", "value"))
+        eq_(0, self.redis.hset(hashkey, "key", "value"))
         eq_("value", self.redis.hget(hashkey, "key"))
 
     def test_hget(self):
@@ -51,7 +52,7 @@ class TestRedisHash(object):
 
     def test_hset_integral(self):
         hashkey = "hash"
-        self.redis.hset(hashkey, 1, 2)
+        eq_(1, self.redis.hset(hashkey, 1, 2))
         eq_("2", self.redis.hget(hashkey, 1))
         eq_("2", self.redis.hget(hashkey, "1"))
 
@@ -64,7 +65,7 @@ class TestRedisHash(object):
 
     def test_hmset(self):
         hashkey = "hash"
-        self.redis.hmset(hashkey, {"key1": "value1", "key2": "value2"})
+        eq_(True, self.redis.hmset(hashkey, {"key1": "value1", "key2": "value2"}))
         eq_("value1", self.redis.hget(hashkey, "key1"))
         eq_("value2", self.redis.hget(hashkey, "key2"))
 


### PR DESCRIPTION
I found this bug when testing code that checks redis return values.

hset should return 1L on success and 0L if the field is already set.
hmset should return True instead of None

I figured this would be a small enough fix to commit to the current release
