### PR TITLE
Add support for setbit and getbit operations

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -414,6 +414,9 @@ class MockRedis(object):
     incrby = incr
 
     def setbit(self, key, offset, value):
+        """
+        Set the bit at ``offset`` in ``key`` to ``value``.
+        """
         key = self._encode(key)
         index, bits, mask = self._get_bits_and_offset(key, offset)
 
@@ -432,6 +435,9 @@ class MockRedis(object):
         return prev_val
 
     def getbit(self, key, offset):
+        """
+        Returns the bit value at ``offset`` in ``key``.
+        """
         key = self._encode(key)
         index, bits, mask = self._get_bits_and_offset(key, offset)
 

--- a/mockredis/tests/test_string.py
+++ b/mockredis/tests/test_string.py
@@ -277,3 +277,29 @@ class TestRedisString(object):
         eq_(None, self.redis.getset('getset_key', '1'))
         eq_(b'1', self.redis.getset('getset_key', '2'))
         eq_(b'2', self.redis.get('getset_key'))
+
+
+    def test_setbit(self):
+
+        # test behavior on empty keys
+        eq_(0, self.redis.getbit("setbit_key", 0))
+        eq_(0, self.redis.getbit("setbit_key", 1024))
+        eq_(None, self.redis.get("setbit_key"))
+
+        # test setting bits and getting bits
+        for x in range(64):
+            eq_(0, self.redis.setbit("setbit_key", x, 1))
+            eq_(1, self.redis.getbit("setbit_key", x))
+            eq_(1, self.redis.setbit("setbit_key", x, 0))
+            eq_(0, self.redis.getbit("setbit_key", x))
+
+        # test setting string and getting bits
+        eq_(True, self.redis.set("setbit_key", b"\xaa\xaa"))
+        for x in range(0, 16, 2):
+            eq_(1, self.redis.getbit("setbit_key", x))
+            eq_(0, self.redis.getbit("setbit_key", x+1))
+
+        # test setting bits and getting string
+        for x in range(16, 32, 2):
+            eq_(0, self.redis.setbit("setbit_key", x, 1))
+        eq_(b"\xaa\xaa\xaa\xaa", self.redis.get("setbit_key"))


### PR DESCRIPTION
This is a straightforward implementation of [SETBIT](http://redis.io/commands/setbit) and [GETBIT](http://redis.io/commands/getbit) redis operations.