### PR TITLE
Change hash method keyword parameters to match redis-py

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -454,28 +454,28 @@ class MockRedis(object):
 
     # Hash Functions #
 
-    def hexists(self, hashkey, attribute):
+    def hexists(self, name, key):
         """Emulate hexists."""
 
-        redis_hash = self._get_hash(hashkey, 'HEXISTS')
-        return self._encode(attribute) in redis_hash
+        redis_hash = self._get_hash(name, 'HEXISTS')
+        return self._encode(key) in redis_hash
 
-    def hget(self, hashkey, attribute):
+    def hget(self, name, key):
         """Emulate hget."""
 
-        redis_hash = self._get_hash(hashkey, 'HGET')
-        return redis_hash.get(self._encode(attribute))
+        redis_hash = self._get_hash(name, 'HGET')
+        return redis_hash.get(self._encode(key))
 
-    def hgetall(self, hashkey):
+    def hgetall(self, name):
         """Emulate hgetall."""
 
-        redis_hash = self._get_hash(hashkey, 'HGETALL')
+        redis_hash = self._get_hash(name, 'HGETALL')
         return dict(redis_hash)
 
-    def hdel(self, hashkey, *keys):
+    def hdel(self, name, *keys):
         """Emulate hdel"""
 
-        redis_hash = self._get_hash(hashkey, 'HDEL')
+        redis_hash = self._get_hash(name, 'HDEL')
         count = 0
         for key in keys:
             attribute = self._encode(key)
@@ -483,59 +483,59 @@ class MockRedis(object):
                 count += 1
                 del redis_hash[attribute]
                 if not redis_hash:
-                    self.delete(hashkey)
+                    self.delete(name)
         return count
 
-    def hlen(self, hashkey):
+    def hlen(self, name):
         """Emulate hlen."""
-        redis_hash = self._get_hash(hashkey, 'HLEN')
+        redis_hash = self._get_hash(name, 'HLEN')
         return len(redis_hash)
 
-    def hmset(self, hashkey, value):
+    def hmset(self, name, mapping):
         """Emulate hmset."""
 
-        redis_hash = self._get_hash(hashkey, 'HMSET', create=True)
-        for key, value in value.items():
+        redis_hash = self._get_hash(name, 'HMSET', create=True)
+        for key, value in mapping.items():
             attribute = self._encode(key)
             redis_hash[attribute] = self._encode(value)
         return True
 
-    def hmget(self, hashkey, keys, *args):
+    def hmget(self, name, keys, *args):
         """Emulate hmget."""
 
-        redis_hash = self._get_hash(hashkey, 'HMGET')
+        redis_hash = self._get_hash(name, 'HMGET')
         attributes = self._list_or_args(keys, args)
         return [redis_hash.get(self._encode(attribute)) for attribute in attributes]
 
-    def hset(self, hashkey, attribute, value):
+    def hset(self, name, key, value):
         """Emulate hset."""
 
-        redis_hash = self._get_hash(hashkey, 'HSET', create=True)
-        attribute = self._encode(attribute)
+        redis_hash = self._get_hash(name, 'HSET', create=True)
+        attribute = self._encode(key)
         attribute_present = attribute in redis_hash
         redis_hash[attribute] = self._encode(value)
         return long(0) if attribute_present else long(1)
 
-    def hsetnx(self, hashkey, attribute, value):
+    def hsetnx(self, name, key, value):
         """Emulate hsetnx."""
 
-        redis_hash = self._get_hash(hashkey, 'HSETNX', create=True)
-        attribute = self._encode(attribute)
+        redis_hash = self._get_hash(name, 'HSETNX', create=True)
+        attribute = self._encode(key)
         if attribute in redis_hash:
             return long(0)
         else:
             redis_hash[attribute] = self._encode(value)
             return long(1)
 
-    def hincrby(self, hashkey, attribute, increment=1):
+    def hincrby(self, name, key, amount=1):
         """Emulate hincrby."""
 
-        return self._hincrby(hashkey, attribute, 'HINCRBY', long, increment)
+        return self._hincrby(name, key, 'HINCRBY', long, amount)
 
-    def hincrbyfloat(self, hashkey, attribute, increment=1.0):
+    def hincrbyfloat(self, name, key, amount=1.0):
         """Emulate hincrbyfloat."""
 
-        return self._hincrby(hashkey, attribute, 'HINCRBYFLOAT', float, increment)
+        return self._hincrby(name, key, 'HINCRBYFLOAT', float, amount)
 
     def _hincrby(self, hashkey, attribute, command, type_, increment):
         """Shared hincrby and hincrbyfloat routine"""
@@ -545,16 +545,16 @@ class MockRedis(object):
         redis_hash[attribute] = self._encode(previous_value + increment)
         return type_(redis_hash[attribute])
 
-    def hkeys(self, hashkey):
+    def hkeys(self, name):
         """Emulate hkeys."""
 
-        redis_hash = self._get_hash(hashkey, 'HKEYS')
+        redis_hash = self._get_hash(name, 'HKEYS')
         return redis_hash.keys()
 
-    def hvals(self, hashkey):
+    def hvals(self, name):
         """Emulate hvals."""
 
-        redis_hash = self._get_hash(hashkey, 'HVALS')
+        redis_hash = self._get_hash(name, 'HVALS')
         return redis_hash.values()
 
     # List Functions #

--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -964,10 +964,9 @@ class MockRedis(object):
         """Emulate sismember."""
         redis_set = self._get_set(name, 'SISMEMBER')
         if not redis_set:
-            return 0
+            return False
 
-        result = self._encode(value) in redis_set
-        return 1 if result else 0
+        return self._encode(value) in redis_set
 
     def smembers(self, name):
         """Emulate smembers."""

--- a/mockredis/tests/test_hash.py
+++ b/mockredis/tests/test_hash.py
@@ -18,12 +18,14 @@ class TestRedisHash(object):
         self.redis.hset(hashkey, "key", "value")
         ok_(self.redis.hexists(hashkey, "key"))
         ok_(not self.redis.hexists(hashkey, "key2"))
+        ok_(self.redis.hexists(name=hashkey, key="key"))
 
     def test_hgetall(self):
         hashkey = "hash"
         eq_({}, self.redis.hgetall(hashkey))
         self.redis.hset(hashkey, "key", "value")
         eq_({b"key": b"value"}, self.redis.hgetall(hashkey))
+        eq_({b"key": b"value"}, self.redis.hgetall(name=hashkey))
 
     def test_hdel(self):
         hashkey = "hash"
@@ -41,17 +43,20 @@ class TestRedisHash(object):
         hashkey = "hash"
         eq_(0, self.redis.hlen(hashkey))
         self.redis.hset(hashkey, "key", "value")
-        eq_(1, self.redis.hlen(hashkey))
+        eq_(1, self.redis.hlen(name=hashkey))
 
     def test_hset(self):
         hashkey = "hash"
         eq_(1, self.redis.hset(hashkey, "key", "value"))
         eq_(b"value", self.redis.hget(hashkey, "key"))
         eq_(0, self.redis.hset(hashkey, "key", "value2"))
+        eq_(0, self.redis.hset(name=hashkey, key="key", value="value2"))
 
     def test_hget(self):
         hashkey = "hash"
         eq_(None, self.redis.hget(hashkey, "key"))
+        eq_(1, self.redis.hset(hashkey, "key", "value"))
+        eq_(b"value", self.redis.hget(name=hashkey, key="key"))
 
     def test_hset_integral(self):
         hashkey = "hash"
@@ -65,12 +70,18 @@ class TestRedisHash(object):
         eq_(b"value1", self.redis.hget(hashkey, "key"))
         eq_(0, self.redis.hsetnx(hashkey, "key", "value2"))
         eq_(b"value1", self.redis.hget(hashkey, "key"))
+        eq_(0, self.redis.hsetnx(name=hashkey, key="key", value="value2"))
+        eq_(b"value1", self.redis.hget(hashkey, "key"))
 
     def test_hmset(self):
         hashkey = "hash"
         eq_(True, self.redis.hmset(hashkey, {"key1": "value1", "key2": "value2"}))
         eq_(b"value1", self.redis.hget(hashkey, "key1"))
         eq_(b"value2", self.redis.hget(hashkey, "key2"))
+        eq_(True, self.redis.hmset(name=hashkey,
+                                   mapping={"key3": "value1", "key4": "value2"}))
+        eq_(b"value1", self.redis.hget(hashkey, "key3"))
+        eq_(b"value2", self.redis.hget(hashkey, "key4"))
 
     def test_hmset_integral(self):
         hashkey = "hash"
@@ -86,25 +97,28 @@ class TestRedisHash(object):
         eq_([b"2", None, b"4"], self.redis.hmget(hashkey, "1", "2", "3"))
         eq_([b"2", None, b"4"], self.redis.hmget(hashkey, ["1", "2", "3"]))
         eq_([b"2", None, b"4"], self.redis.hmget(hashkey, [1, 2, 3]))
+        eq_([b"2", None, b"4"], self.redis.hmget(name=hashkey, keys=[1, 2, 3]))
 
     def test_hincrby(self):
         hashkey = "hash"
         eq_(1, self.redis.hincrby(hashkey, "key", 1))
-        eq_(3, self.redis.hincrby(hashkey, "key", 2))
+        eq_(3, self.redis.hincrby(name=hashkey, key="key", amount=2))
         eq_(b"3", self.redis.hget(hashkey, "key"))
 
     def test_hincrbyfloat(self):
         hashkey = "hash"
         eq_(1.2, self.redis.hincrbyfloat(hashkey, "key", 1.2))
-        eq_(3.5, self.redis.hincrbyfloat(hashkey, "key", 2.3))
+        eq_(3.5, self.redis.hincrbyfloat(name=hashkey, key="key", amount=2.3))
         eq_(b"3.5", self.redis.hget(hashkey, "key"))
 
     def test_hkeys(self):
         hashkey = "hash"
         self.redis.hmset(hashkey, {1: 2, 3: 4})
         eq_([b"1", b"3"], sorted(self.redis.hkeys(hashkey)))
+        eq_([b"1", b"3"], sorted(self.redis.hkeys(name=hashkey)))
 
     def test_hvals(self):
         hashkey = "hash"
         self.redis.hmset(hashkey, {1: 2, 3: 4})
         eq_([b"2", b"4"], sorted(self.redis.hvals(hashkey)))
+        eq_([b"2", b"4"], sorted(self.redis.hvals(name=hashkey)))

--- a/mockredis/tests/test_set.py
+++ b/mockredis/tests/test_set.py
@@ -121,7 +121,7 @@ class TestRedisSet(object):
         eq_(1, self.redis.sadd(key, "one"))
         ok_(self.redis.sismember(key, "one"))
         ok_(not self.redis.sismember(key, "two"))
-        eq_(0, self.redis.sismember(key, "two"))
+        eq_(False, self.redis.sismember(key, "two"))
 
     def test_ismember_numeric(self):
         """


### PR DESCRIPTION
In order to call redis commands while specifying keyword args explicitly, they must match with redis-py. An example of when this would be absolutely necessary is using `functool.partial` to create an hget method (say from a pipleine) that fetches a certain field from a set of keys it's subsequently mapped over.