### PR TITLE
redis-py 2.10.0: new param in StrictRedis:lock method

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -67,9 +67,9 @@ class MockRedis(object):
 
     # Transactions Functions #
 
-    def lock(self, key, timeout=0, sleep=0):
+    def lock(self, key, timeout=0, sleep=0, blocking_timeout=None):
         """Emulate lock."""
-        return MockRedisLock(self, key, timeout, sleep)
+        return MockRedisLock(self, key, timeout, sleep, blocking_timeout)
 
     def pipeline(self, transaction=True, shard_hint=None):
         """Emulate a redis-python pipeline."""

--- a/mockredis/lock.py
+++ b/mockredis/lock.py
@@ -4,7 +4,7 @@ class MockRedisLock(object):
     to allow testing without a real redis server.
     """
 
-    def __init__(self, redis, name, timeout=None, sleep=0.1):
+    def __init__(self, redis, name, timeout=None, sleep=0.1, blocking_timeout=None):
         """Initialize the object."""
 
         self.redis = redis
@@ -12,6 +12,7 @@ class MockRedisLock(object):
         self.acquired_until = None
         self.timeout = timeout
         self.sleep = sleep
+        self.blocking_timeout = blocking_timeout
 
     def acquire(self, blocking=True):  # pylint: disable=R0201,W0613
         """Emulate acquire."""

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 # Match releases to redis-py versions
-__version__ = '2.9.0.12'
+__version__ = '2.10.0'
 
 # Jenkins will replace __build__ with a unique value.
 __build__ = ''
@@ -21,7 +21,7 @@ setup(name='mockredispy',
           'lua': ['lunatic-python-bugfix==1.1.1'],
       },
       tests_require=[
-          'redis>=2.9.0'
+          'redis>=2.10.0'
       ],
       test_suite='mockredis.tests',
       entry_points={


### PR DESCRIPTION
This PR won't be that useful until a decision is made to mock `redis-py 2.10.0`...