### PR TITLE
Handle non-str Lua parameters

### DIFF
--- a/mockredis/script.py
+++ b/mockredis/script.py
@@ -17,8 +17,16 @@ class Script(object):
 
         if not client.script_exists(self.sha)[0]:
             self.sha = client.script_load(self.script)
-
-        return self._execute_lua(keys, args, client)
+        
+        str_keys = []
+        for key in keys:
+            str_keys.append(str(key))
+        
+        str_args = []
+        for arg in args:
+            str_args.append(str(arg))
+            
+        return self._execute_lua(str_keys, str_args, client)
 
     def _execute_lua(self, keys, args, client):
         """

--- a/mockredis/script.py
+++ b/mockredis/script.py
@@ -24,7 +24,7 @@ class Script(object):
             if not client.script_exists(self.sha)[0]:
                 self.sha = client.script_load(self.script)
 
-            return self._execute_lua(keys, args, client)
+            return self._execute_lua([str(key) for key in keys], [str(arg) for arg in args], client)
 
     def _execute_lua(self, keys, args, client):
         """


### PR DESCRIPTION
This is required when passing non-str keys or arguments to Lua scripts.
