### PR TITLE
Add support for `from_url` constructors

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -58,6 +58,10 @@ class MockRedis(object):
         # Dictionary from script to sha ''Script''
         self.shas = dict()
 
+    @classmethod
+    def from_url(cls, url, db=None, **kwargs):
+        return cls(**kwargs)
+
     # Connection Functions #
 
     def echo(self, msg):
@@ -1509,6 +1513,8 @@ def mock_redis_client(**kwargs):
     """
     return MockRedis()
 
+mock_redis_client.from_url = mock_redis_client
+
 
 def mock_strict_redis_client(**kwargs):
     """
@@ -1517,3 +1523,5 @@ def mock_strict_redis_client(**kwargs):
     instead of a StrictRedis object.
     """
     return MockRedis(strict=True)
+
+mock_strict_redis_client.from_url = mock_strict_redis_client

--- a/mockredis/tests/test_factories.py
+++ b/mockredis/tests/test_factories.py
@@ -13,8 +13,22 @@ def test_mock_redis_client():
     ok_(not mock_redis_client(host="localhost", port=6379).strict)
 
 
+def test_mock_redis_client_from_url():
+    """
+    Test that we can pass kwargs to the Redis from_url mock/patch target.
+    """
+    ok_(not mock_redis_client.from_url(host="localhost", port=6379).strict)
+
+
 def test_mock_strict_redis_client():
     """
     Test that we can pass kwargs to the StrictRedis mock/patch target.
     """
     ok_(mock_strict_redis_client(host="localhost", port=6379).strict)
+
+
+def test_mock_strict_redis_client_from_url():
+    """
+    Test that we can pass kwargs to the StrictRedis from_url mock/patch target.
+    """
+    ok_(mock_strict_redis_client.from_url(host="localhost", port=6379).strict)


### PR DESCRIPTION
This pull request adds support for the `Redis.from_url()` and `StrictRedis.from_url()` constructors. Please let me know if there's anything else this pull request needs in order to be merged.