### PR TITLE
Removed re.sub('*', '[^/]*') in keys()

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -161,8 +161,7 @@ class MockRedis(object):
             pass
 
         # Make regex out of glob styled pattern.
-        regex = fnmatch.translate(pattern)
-        regex = re.compile(re.sub(r'(^|[^\\])\.', r'\1[^/]', regex))
+        regex = re.compile(fnmatch.translate(pattern))
 
         # Find every key that matches the pattern
         return [key for key in self.redis.keys() if regex.match(key.decode('utf-8'))]


### PR DESCRIPTION
[Redis KEYS](http://redis.io/commands/KEYS) `*` should match everthing.
This commit fixes an issue where it matches everything up to the first slash `/`