### PR TITLE
Add basic config_set / config_get support.

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -53,6 +53,7 @@ class MockRedis(object):
         self.blocking_sleep_interval = blocking_sleep_interval
         # The 'Redis' store
         self.redis = defaultdict(dict)
+        self.redis_config = defaultdict(dict)
         self.timeouts = defaultdict(dict)
         # The 'PubSub' store
         self.pubsub = defaultdict(list)
@@ -1395,6 +1396,27 @@ class MockRedis(object):
                 return [value for tpl in response for value in tpl]
 
         return response
+
+    # Config Set/Get commands #
+
+    def config_set(self, name, value):
+        """
+        Set a configuration parameter.
+        """
+        self.redis_config[name] = value
+
+    def config_get(self, pattern='*'):
+        """
+        Get one or more configuration parameters.
+        """
+        result = {}
+        for name, value in self.redis_config.items():
+            if fnmatch.fnmatch(name, pattern):
+                try:
+                    result[name] = int(value)
+                except ValueError:
+                    result[name] = value
+        return result
 
     # PubSub commands #
 

--- a/mockredis/tests/test_config.py
+++ b/mockredis/tests/test_config.py
@@ -1,0 +1,20 @@
+from nose.tools import eq_, ok_
+
+from mockredis.tests.fixtures import setup, teardown
+
+
+class TestRedisConfig(object):
+    """Redis config set/get tests"""
+
+    def setup(self):
+        setup(self)
+
+    def teardown(self):
+        teardown(self)
+
+    def test_config_set(self):
+        eq_(self.redis.config_get('config-param'), {})
+        self.redis.config_set('config-param', 'value')
+        eq_(self.redis.config_get('config-param'), {'config-param': 'value'})
+        eq_(self.redis.config_get('config*'), {'config-param': 'value'})
+


### PR DESCRIPTION
This PR replace #84. It is made on an updated master.
It is a very basic implementation and it lacks defaults, special handling of multi-line config keywords, etc.