### PR TITLE
Allow range arguments to come as string.

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -1444,6 +1444,8 @@ class MockRedis(object):
         """
         Translate range to valid bounds.
         """
+        start = int(start)
+        end = int(end)
         if start < 0:
             start += len_
         start = max(0, min(start, len_))


### PR DESCRIPTION
MockRedis._translate_range() assumed start and end to be integers but Redis use string for arguments.
Using commands with string range arguments caused errors.
e.g.:
`mock_redis.zrange('myzset', '0', '-1') #  Always return an empty list before the fix.`