### PR TITLE
Removed travis use of no longer supported pip switch --use-mirrors .

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 - '3.4'
 - pypy
 - pypy3
-install: pip install . --use-mirrors
+install: pip install .
 script: python setup.py nosetests
 deploy:
   provider: pypi


### PR DESCRIPTION
Build tests fail on old pip --use-mirrors switch which is no longer supported and isn't needed.
This commit remove the switch from Travis configuration install command.
