### PR TITLE
Support decode_responses

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -1585,7 +1585,7 @@ def mock_redis_client(**kwargs):
     can return a MockRedis object
     instead of a Redis object.
     """
-    return MockRedis()
+    return MockRedis(**kwargs)
 
 mock_redis_client.from_url = mock_redis_client
 
@@ -1596,6 +1596,6 @@ def mock_strict_redis_client(**kwargs):
     can return a MockRedis object
     instead of a StrictRedis object.
     """
-    return MockRedis(strict=True)
+    return MockRedis(strict=True, **kwargs)
 
 mock_strict_redis_client.from_url = mock_strict_redis_client


### PR DESCRIPTION
Here is an update for mockredispy, which brings the `decode_responses` kwarg support for Redis classes.