### PR TITLE
Add documentation for expiration management

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,34 @@ Or:
 
     @patch('redis.StrictRedis', mock_strict_redis_client)
 
+
+### Time expiration
+
+For time expiration management, a custom clock has to be implemented to overwrite
+the default internal clock. The default internal clock only uses `datetime.now()`
+and won't be able to simulate time jump. A simple clock implementation with the
+ability to add or substract time can be found below. Then, instead of using
+`mock_redis_client` or `mock_strict_redis_client`, use
+`MockRedis(clock=CustomClock())` or `MockRedis(strict=True, clock=CustomClock())`.
+The clock is then accessible through `redis.client`.
+
+```python
+from datetime import datetime, timedelta
+from mockredis import clock
+
+
+class CustomClock(clock.Clock):
+    def __init__(self):
+        self.timeout = 0
+
+    def add_timeout(self, timeout):
+        self.timeout += timeout
+
+    def now(self):
+        return datetime.now() + timedelta(seconds=self.timeout)
+```
+
+
 ## Testing
 
 Many unit tests exist to verify correctness of mock functionality. In addition, most

--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -30,8 +30,9 @@ class MockRedis(object):
     A Mock for a redis-py Redis object
 
     Expire functionality must be explicitly
-    invoked using do_expire(time). Automatic
-    expiry is NOT supported.
+    invoked using do_expire(). Automatic
+    expiry is NOT supported. Please refer to
+    the README on how to manage time expiration.
     """
 
     def __init__(self,
@@ -257,7 +258,7 @@ class MockRedis(object):
 
     def do_expire(self):
         """
-        Expire objects assuming now == time
+        Expire objects regarding the internal clock 'now()' value
         """
         # Deep copy to avoid RuntimeError: dictionary changed size during iteration
         _timeouts = deepcopy(self.timeouts)


### PR DESCRIPTION
The comments are out of date in the `client.py` file, and there is no mention anywhere how to manage time expiration. I added a section in the README describing how to manage time expiration with a small custom clock.