### PR TITLE
Implement `persist` command

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -214,6 +214,14 @@ class MockRedis(object):
             return True
         return False
 
+    def persist(self, key):
+        """Emulate persist"""
+        try:
+            del self.timeouts[key]
+            return True
+        except KeyError:
+            return False
+
     def ttl(self, key):
         """
         Emulate ttl

--- a/mockredis/tests/test_redis.py
+++ b/mockredis/tests/test_redis.py
@@ -174,6 +174,33 @@ class TestRedis(object):
         # should be less than the timeout originally set
         ok_(result <= 30, "Expected {} to be less than 30".format(result))
 
+    def test_persist(self):
+        """
+        Test whether persist removes ttl.
+        """
+        self.redis.set('key', 'key')
+        self.redis.expire('key', 30)
+
+        result = self.redis.persist('key')
+        eq_(result, True)
+        eq_(self.redis.ttl('key'), None)
+
+    def test_persist_no_timeout(self):
+        """
+        Test whether persist returns False when no timeout is set.
+        """
+        self.redis.set('key', 'key')
+
+        result = self.redis.persist('key')
+        eq_(result, False)
+
+    def test_persist_no_key(self):
+        """
+        Test whether persist returns False when key does not exist.
+        """
+        result = self.redis.persist('key')
+        eq_(result, False)
+
     def test_keys(self):
         eq_([], self.redis.keys("*"))
 


### PR DESCRIPTION
As per https://redis.io/commands/persist and http://redis-py.readthedocs.io/en/latest/#redis.StrictRedis.persist.