### PR TITLE
Added time support

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -189,6 +189,17 @@ class MockRedis(object):
         return self._encode(key) in self.redis
     __contains__ = exists
 
+    def time(self):
+        """
+        Emulate time
+
+        :returns: a tuple of the current Unix timestamp, and the amount of
+                  microseconds already elapsed in the current second.
+        """
+        now = datetime.utcnow()
+        return int(time.mktime(now.timetuple())), now.microsecond
+
+
     def _expire(self, key, delta):
         if key not in self.redis:
             return False

--- a/mockredis/tests/test_redis.py
+++ b/mockredis/tests/test_redis.py
@@ -92,6 +92,17 @@ class TestRedis(object):
         self.redis.decr('dkey')
         eq_(b'-1', self.redis.get('dkey'))
 
+    def test_time_format(self):
+        result = self.redis.time()
+        ok_(isinstance(result, tuple))
+        eq_(len(result), 2)
+
+        timestamp, millis = result
+        ok_(isinstance(timestamp, int))
+        ok_(timestamp > 0)
+        ok_(isinstance(millis, int))
+        ok_(millis > 0)
+
     def test_ttl(self):
         self.redis.set('key', 'key')
         self.redis.expire('key', 30)


### PR DESCRIPTION
As originally submitted by @nburns in https://github.com/locationlabs/mockredis/pull/89 hereby support for time().