### PR TITLE
HMSET should fail on empty mapping.

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -539,6 +539,8 @@ class MockRedis(object):
 
     def hmset(self, hashkey, value):
         """Emulate hmset."""
+        if len(value) == 0:
+            raise ResponseError("empty mapping passed to 'hmset'")
 
         redis_hash = self._get_hash(hashkey, 'HMSET', create=True)
         for key, value in value.items():

--- a/mockredis/tests/test_hash.py
+++ b/mockredis/tests/test_hash.py
@@ -1,6 +1,6 @@
 from nose.tools import eq_, ok_
 
-from mockredis.tests.fixtures import setup, teardown
+from mockredis.tests.fixtures import raises_response_error, setup, teardown
 
 
 class TestRedisHash(object):
@@ -71,6 +71,10 @@ class TestRedisHash(object):
         eq_(True, self.redis.hmset(hashkey, {"key1": "value1", "key2": "value2"}))
         eq_(b"value1", self.redis.hget(hashkey, "key1"))
         eq_(b"value2", self.redis.hget(hashkey, "key2"))
+
+    @raises_response_error
+    def test_hmset_empty(self):
+        self.redis.hmset("hash", {})
 
     def test_hmset_integral(self):
         hashkey = "hash"


### PR DESCRIPTION
We've hit this error a few time in production where `redis` throws an error on an empty mapping.

https://github.com/andymccurdy/redis-py/blob/413e802f8fe390738bc1e89716083586e0269fd0/redis/client.py#L2003-L2009

This is similar to #146 but for HMSET.